### PR TITLE
feat: add macro LUA_USE_LIBC_JUMP_PSX

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -46,7 +46,7 @@
 ** longjmp/setjmp otherwise.
 */
 
-#ifdef LUA_TARGET_PSX
+#if defined(LUA_TARGET_PSX) && !defined(LUA_USE_LIBC_JUMP_PSX)
 struct JmpBuf { void * regs[12]; };
 static inline int syscall_setjmp(struct JmpBuf *buf) {
     register int n asm("t1") = 0x13;


### PR DESCRIPTION
this adjustment makes it easier for those using PSn00bSDK, or some libc implementation for `longjmp` and `setjmp` #2 